### PR TITLE
centralized the font and made whole browse and upload boxes clickable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply bg-darkblue text-creme;
-  font-family: Arial, Helvetica, sans-serif;
+  @apply bg-darkblue text-creme font-sans;
 }

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,9 +1,30 @@
+/**
+ * UploadPage Component.
+ *
+ * @remarks
+ * This component serves as the main upload page for the application. It renders both the file upload form
+ * and the video processing progress display. The page is wrapped by two context providers:
+ *
+ * - WebSocketProvider: Supplies real-time updates from the backend via a WebSocket connection, including processing
+ *   messages, milestones, and progress data.
+ *
+ * - UploadFileProvider: Manages and shares the download state (download URL and filename) across the application.
+ *
+ * The wrapping ensures that both the UploadForm and ProcessVideoWebSocket components have access to the shared
+ * download link state. The UploadForm handles file selection and triggers the upload process, while the
+ * ProcessVideoWebSocket component displays processing status and, upon a successful upload, renders a clickable
+ * download link based on the shared state.
+ *
+ * @returns {JSX.Element} The rendered UploadPage component.
+ *
+ * @example
+ * <UploadPage />
+ */
 "use client";
 import React from "react";
 import UploadForm from "@/components/UploadForm";
 import ProcessVideoWebSocket from "@/components/ProcessVideoWebSocket";
 import { WebSocketProvider } from "@/components/WebSocketContext";
-
 import { UploadFileProvider } from "@/components/UploadFileContext";
 
 export default function UploadPage() {

--- a/components/UploadForm.tsx
+++ b/components/UploadForm.tsx
@@ -1,34 +1,37 @@
-/**
- * UploadForm Component.
- *
- * @remarks
- * Renders a file upload form that allows users to browse for a file and initiate an upload.
- * Upon initiating the upload, the component sends the file to the backend and updates the
- * download link state via the UploadFileContext.
- *
- * This component manages two phases: the "initial" phase displays the file input and upload button,
- * while the "detailed" phase triggers the file upload.
- *
- * @returns {JSX.Element | null} The rendered upload form when in the initial phase; otherwise, null.
- */
 "use client";
 import React, { useState, useEffect } from "react";
 import { useUploadFile } from "./UploadFileContext";
 
+/**
+ * UploadForm Component.
+ *
+ * @remarks
+ * This component renders a file upload form that allows users to select a file (via a "Browse" box)
+ * and initiate an upload (via an "Upload" box). The component maintains two phases:
+ * - "initial": Renders the file input and upload button.
+ * - "detailed": Initiates the file upload process.
+ *
+ * In the "detailed" phase, the file is sent to a backend endpoint using a POST request.
+ * The component uses the UploadFileContext to update the download link once the upload is complete.
+ *
+ * Tailwind classes are applied to ensure that the entire boxes (for both "Browse" and "Upload") are clickable.
+ *
+ * @returns {JSX.Element | null} The rendered upload form during the "initial" phase, or null otherwise.
+ */
 const UploadForm: React.FC = () => {
+  // Component state management
   const [phase, setPhase] = useState<"initial" | "detailed">("initial");
   const [file, setFile] = useState<File | null>(null);
   const [hasUploaded, setHasUploaded] = useState(false);
   const { setDownloadLink } = useUploadFile();
 
   /**
-   * Handles the change event on the file input element.
+   * Handles changes to the file input.
    *
    * @remarks
-   * Retrieves the selected file from the event and updates the component state. Also resets the upload flag.
+   * When a user selects a file, this handler updates the state with the selected file and resets the upload flag.
    *
-   * @param e - The change event from the file input.
-   * @returns {void}
+   * @param {React.ChangeEvent<HTMLInputElement>} e - The change event triggered by the file input.
    */
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = e.target.files?.[0] || null;
@@ -37,13 +40,11 @@ const UploadForm: React.FC = () => {
   };
 
   /**
-   * Handles the click event on the upload button.
+   * Handles the click event on the upload box.
    *
    * @remarks
-   * Verifies that a file has been selected. If no file is selected, alerts the user.
-   * Otherwise, transitions the component to the "detailed" phase to trigger the upload process.
-   *
-   * @returns {void}
+   * Verifies that a file has been selected. If not, it alerts the user.
+   * If a file is selected, the component phase is changed to "detailed" to trigger the file upload process.
    */
   const handleInitialUploadClick = () => {
     if (!file) {
@@ -54,15 +55,16 @@ const UploadForm: React.FC = () => {
   };
 
   /**
-   * Effect hook to handle file upload when the component phase changes to "detailed".
+   * Effect hook that initiates the file upload process when the component phase changes to "detailed".
    *
    * @remarks
-   * This effect defines an asynchronous function that constructs a FormData object with the selected file,
-   * sends it to the backend using a POST request, and processes the response. Depending on the response,
-   * it updates the download link state via the setDownloadLink function from the UploadFileContext.
-   * The effect ensures that the upload only occurs once per file selection by checking the hasUploaded flag.
+   * The effect defines an asynchronous function that:
+   * - Constructs a FormData object with the selected file.
+   * - Sends the file to the backend using a POST request.
+   * - Parses the response and updates the download link via the UploadFileContext.
+   * - Handles error scenarios by logging to the console.
    *
-   * @returns {void} A cleanup function is not required in this effect.
+   * The effect is re-triggered whenever the phase, file, hasUploaded flag, or setDownloadLink function changes.
    */
   useEffect(() => {
     const uploadFile = async (): Promise<void> => {
@@ -100,6 +102,7 @@ const UploadForm: React.FC = () => {
         }
       }
     };
+
     uploadFile();
   }, [phase, file, hasUploaded, setDownloadLink]);
 
@@ -107,27 +110,28 @@ const UploadForm: React.FC = () => {
     return (
       <div className="min-h-screen flex flex-col items-center justify-center p-4 bg-darkblue">
         <div className="flex flex-col space-y-4 w-full max-w-md">
-          <div className="p-8 bg-burntorange rounded shadow">
-            <label
-              htmlFor="file-input"
-              className="block text-white text-xl cursor-pointer text-center"
-            >
+          <label
+            htmlFor="file-input"
+            className="cursor-pointer p-8 bg-burntorange rounded shadow"
+          >
+            <span className="block text-white text-xl text-center">
               Browse
-            </label>
+            </span>
             <input
               type="file"
               id="file-input"
               onChange={handleFileChange}
               className="hidden"
             />
-          </div>
-          <div className="p-8 bg-burntorange rounded shadow">
-            <button
-              onClick={handleInitialUploadClick}
-              className="w-full text-white text-xl"
-            >
+          </label>
+          <div
+            role="button"
+            onClick={handleInitialUploadClick}
+            className="cursor-pointer p-8 bg-burntorange rounded shadow"
+          >
+            <span className="block text-white text-xl text-center">
               Upload
-            </button>
+            </span>
           </div>
         </div>
       </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,9 +9,9 @@ export default {
   theme: {
     extend: {
       colors: {
-        darkblue: "#1a5276",   // Darker blue background
-        creme: "#bdb5b0",      // Creme text color
-        burntorange: "#ba4a00",// Burnt orange for borders/buttons
+        darkblue: "#1a5276", // Darker blue background
+        creme: "#bdb5b0",    // Creme text color
+        burntorange: "#ba4a00", // Burnt orange for borders/buttons
       },
     },
   },


### PR DESCRIPTION
In globals.css, the font-family declaration was centralized with Tailwind. The UploadPage component now includes detailed docs explaining the recently added UploadFileContext provider. The UploadForm component was updated with a fully clickable area for the whole of both the "Browse" and "Upload" buttons. 